### PR TITLE
fix(pypi): include json expectations in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include requirements.txt
 include requirements-dev.txt
 include README.md
 include mathy_core/py.typed
-recursive-include mathy_core/tests *
+recursive-include mathy_core *.json


### PR DESCRIPTION
The latest package cannot be used because it doesn't include the json files from the source directory. 

A better fix would include an update the test step that deletes the source folder after building the package, then installs that package and runs the tests.

For now, I've fixed the manifest file to include the JSON files.