### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,7 +990,7 @@ BalancedMoveRule(self, args, kwargs)
 Balanced rewrite rule moves nodes from one side of an equation
 to the other by performing the same operation on both sides.
 
-Addition: `a + 2 = 3` -> `a + 2 = 3 - 2`
+Addition: `a + 2 = 3` -> `a + 2 - 2 = 3 - 2`
 Multiplication: `3a = 3` -> `3a / 3 = 3 / 3`
 
 ### get_type <kbd>method</kbd>


### PR DESCRIPTION
Fix a typo where only  " - 2 " is on one side of the " = " sign. (Line 993, "Balanced rewrite...")
Doing my first open source pull request.