### PR TITLE
Fix/restate subtraction

### DIFF
--- a/mathy_core/rules/distributive_factor_out.py
+++ b/mathy_core/rules/distributive_factor_out.py
@@ -56,6 +56,7 @@ class DistributiveFactorOutRule(BaseRule):
         """Determine the configuration of the tree for this transformation.
 
         Support the three types of tree configurations:
+
          - Simple is where the node's left and right children are exactly
            terms linked by an add operation.
          - Chained Left is where the node's left child is a term, but the right
@@ -66,6 +67,7 @@ class DistributiveFactorOutRule(BaseRule):
            of the child add node is the target.
 
         Structure:
+
          - Simple
             * node(add),node.left(term),node.right(term)
          - Chained Left

--- a/mathy_core/rules/distributive_factor_out.test.json
+++ b/mathy_core/rules/distributive_factor_out.test.json
@@ -4,6 +4,10 @@
   },
   "valid": [
     {
+      "input": "4x + -3x",
+      "output": "(4 + -3) * x"
+    },
+    {
       "input": "g + -x^3 + 4x^3 + 19p^4 + -1y",
       "output": "g + (-1 + 4) * x^3 + 19p^4 + -1y",
       "why": "invariance to sibling grouping"

--- a/mathy_core/rules/restate_subtraction.py
+++ b/mathy_core/rules/restate_subtraction.py
@@ -14,7 +14,7 @@ from ..expressions import (
 from ..rule import BaseRule, ExpressionChangeRule
 
 _OP_SUBTRACTION = "subtraction"
-_OP_SUBTRACTION_NEGATIVE_TERM_WITH_CONST = "subtract-negative-term-with-constant"
+_OP_SUBTRACTION_TERM_WITH_CONST = "subtract-term-with-constant"
 _OP_SUBTRACTION_NEGATIVE_CONST = "subtract-negative-constant"
 _OP_SUBTRACTION_NEGATE_VARIABLE = "subtract-negative-variable"
 _OP_ADD_NEG_CONST = "add_neg_const"
@@ -68,11 +68,13 @@ class RestateSubtractionRule(BaseRule):
                 node.right is not None
                 and isinstance(node.right.left, ConstantExpression)
                 and node.right.left.value is not None
-                and node.right.left.value < 0.0
             ):
                 # 4x - -1x
                 # 3u^2 - -2t^4 + -u^2
-                return _OP_SUBTRACTION_NEGATIVE_TERM_WITH_CONST
+                # 4 - 3x
+                # 12 - -2x^2
+                return _OP_SUBTRACTION_TERM_WITH_CONST
+
             # 4x - 2x
             return _OP_SUBTRACTION
 
@@ -125,8 +127,8 @@ class RestateSubtractionRule(BaseRule):
         result: MathExpression
         new_right: MathExpression
 
-        # Subtract negative to plus positive (2 - -3x^2 => 2 + 3x^2)
-        if tree_type == _OP_SUBTRACTION_NEGATIVE_TERM_WITH_CONST:
+        # Subtract term with const (2 - -3x^2 => 2 + 3x^2) or (2 - 3x => 2 + -3x)
+        if tree_type == _OP_SUBTRACTION_TERM_WITH_CONST:
             assert node.right is not None and node.right.left is not None
             new_right = cast(MultiplyExpression, node.right.clone())
             assert (

--- a/mathy_core/rules/restate_subtraction.test.json
+++ b/mathy_core/rules/restate_subtraction.test.json
@@ -60,6 +60,10 @@
     {
       "input": "2x + -9x^3",
       "output": "2x - 9x^3"
+    },
+    {
+      "input": "4 - 3x",
+      "output": "4 + -3x"
     }
   ],
   "invalid": []

--- a/mathy_core/tree.py
+++ b/mathy_core/tree.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generic, List, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
 
 from .types import Literal
 

--- a/mathy_core/tree.py
+++ b/mathy_core/tree.py
@@ -206,7 +206,7 @@ class BinaryTreeNode(Generic[NodeType]):
         while result.parent:
             result = result.parent  # type:ignore
 
-        return cast(NodeType, result)
+        return result
 
     def get_root_side(self: NodeType) -> Literal["left", "right"]:
         """Return the side of the tree that this node lives on"""


### PR DESCRIPTION
While writing some docs for the site, I noticed an example I created didn't work. There's a simplification bug in the RestateSubtraction rule that I added (while originally writing docs for the site 😅.) 

 - in the case of `4x - 3x` the output `4x + -(3x)` would add a `NegateExpression` around the `3x` term, yielding `Negate(Multiply(Constant, Variable))` instead of Multiply(Constant(Variable))` with a negated constant value.
 - distributive factor out requires the simpler form to be applied, not handling the negation of a term node. 